### PR TITLE
UTC conversion bug for *nix

### DIFF
--- a/source/api/lib/GnssMetadata/Date.cpp
+++ b/source/api/lib/GnssMetadata/Date.cpp
@@ -58,7 +58,9 @@ static time_t UtcYmdhmsToTime_T(int year, int mon, int day, int hour, int min, i
 	temp_tm->tm_year = (year > 1900 ? year - 1900 : year);
 	temp_time_t=mktime(temp_tm);    
 #if defined(_WIN32) || defined(_WIN64)
-	temp_time_t-=_timezone;	// undo any correction for timezone/daylight savings system did
+	temp_time_t -= _timezone;	// undo any correction for timezone/daylight savings system did
+#else
+   	temp_time_t -= timezone;	// undo any correction for timezone/daylight savings system did
 #endif
 
 	return temp_time_t;


### PR DESCRIPTION
Modified UTC conversion to fix time-zone offset under Mac/Linux. 
The use f mktime() can introduce an offset of an hour depending on the timezone. The global variable that holds this offset is stored in "timezone" on *nix and in "_timezone" on Win. 