### PR TITLE
fixed bug (order of System::Type in SystemTranslator.cpp)

### DIFF
--- a/source/api/inc/GnssMetadata/System.h
+++ b/source/api/inc/GnssMetadata/System.h
@@ -40,9 +40,9 @@ namespace GnssMetadata
 		enum SystemType
 		{
 			Undefined=0,
-			Processor,
-			Receiver,
-			Simulator
+            Processor=1,
+            Receiver=2,
+            Simulator=3
 		};
 	public:
 		System( const IonString& id = "", bool bIsReference = false) 

--- a/source/api/lib/GnssMetadata/Xml/SystemTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/SystemTranslator.cpp
@@ -43,7 +43,7 @@ NODELIST_BEGIN(_SystemNodes)
 	NODELIST_ENTRY( "artifact",  TE_SIMPLE_TYPE)
 NODELIST_END
 
-static const char* _szTypes[] = {"Processor","Receiver", "Simulator", "Undefined"};
+static const char* _szTypes[] = {"Undefined", "Processor", "Receiver", "Simulator"};
 System::SystemType ToSystemType( const char* pszFmt)
 {
     for( unsigned int i = 0; i < 4; i++)


### PR DESCRIPTION
bugfix: 
- order of System::Type string was wrong in SystemTranslator.cpp
- fixed order and made it explicit in System.h to be less error prune