### PR TITLE
Fix warnings produced by g++ with -pedantic option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,6 @@ install/log.txt
 install/TestAPI*
 install/TestConverter*
 install/Converter*
-
+CMakeLists.txt.user*
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 # Enable C++11 support in GCC
 # For "-std=c++0x"  GCC's support for C++11 see http://gcc.gnu.org/projects/cxx0x.html
 if(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
-     set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -Wall -Wextra")  #Add warning flags: For "-Wall" see http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+     set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -Wall -Wextra -pedantic")  #Add warning flags: For "-Wall -pedantic" see http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 endif(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -Wno-c++11-narrowing")

--- a/CMakeLists.txt.user
+++ b/CMakeLists.txt.user
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 4.5.83, 2018-03-09T14:10:19. -->
+<qtcreator>
+ <data>
+  <variable>EnvironmentId</variable>
+  <value type="QByteArray">{6aa57961-7a5b-4429-b9d3-953571646c14}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.MarginColumn">80</value>
+   <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SmartSelectionChanging">true</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap"/>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{eda42084-7a19-418f-9c01-681da9651bf9}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <valuelist type="QVariantList" key="CMake.Configuration"/>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/misha/dev/build/build-GNSS-Metadata-Standard-Default</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
+    <valuelist type="QVariantList" key="CMake.Configuration">
+     <value type="QString">CMAKE_BUILD_TYPE:STRING=Debug</value>
+    </valuelist>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/misha/dev/build/build-GNSS-Metadata-Standard-Debug</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
+    <valuelist type="QVariantList" key="CMake.Configuration">
+     <value type="QString">CMAKE_BUILD_TYPE:STRING=Release</value>
+    </valuelist>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/misha/dev/build/build-GNSS-Metadata-Standard-Release</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.3">
+    <valuelist type="QVariantList" key="CMake.Configuration">
+     <value type="QString">CMAKE_BUILD_TYPE:STRING=RelWithDebInfo</value>
+    </valuelist>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/misha/dev/build/build-GNSS-Metadata-Standard-Release with Debug Information</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Release with Debug Information</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release with Debug Information</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.4">
+    <valuelist type="QVariantList" key="CMake.Configuration">
+     <value type="QString">CMAKE_BUILD_TYPE:STRING=MinSizeRel</value>
+    </valuelist>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/misha/dev/build/build-GNSS-Metadata-Standard-Minimum Size Release</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">CMake Build</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Minimum Size Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Minimum Size Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">5</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy Configuration</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.PluginSettings"/>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="int" key="PE.EnvironmentAspect.Base">-1</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Arguments"></value>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Executable"></value>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.WorkingDirectory"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.CustomExecutableRunConfiguration</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">18</value>
+ </data>
+ <data>
+  <variable>Version</variable>
+  <value type="int">18</value>
+ </data>
+</qtcreator>

--- a/CMakeLists.txt.user
+++ b/CMakeLists.txt.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.5.83, 2018-03-09T14:10:19. -->
+<!-- Written by QtCreator 4.5.83, 2018-03-09T14:30:06. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -54,7 +54,9 @@
  </data>
  <data>
   <variable>ProjectExplorer.Project.PluginSettings</variable>
-  <valuemap type="QVariantMap"/>
+  <valuemap type="QVariantMap">
+   <valuelist type="QVariantList" key="ClangStaticAnalyzer.SuppressedDiagnostics"/>
+  </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
@@ -338,14 +340,15 @@
      <value type="int">13</value>
      <value type="int">14</value>
     </valuelist>
-    <value type="int" key="PE.EnvironmentAspect.Base">-1</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguation.Title">Converter</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.Arguments"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory.default">/home/misha/dev/GNSS-Metadata-Standard/install</value>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Arguments"></value>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Executable"></value>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.WorkingDirectory"></value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.CustomExecutableRunConfiguration</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">2</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.Converter</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
@@ -353,7 +356,119 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
    </valuemap>
-   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.1">
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguation.Title">TestAPI</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.Arguments"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory.default">/home/misha/dev/GNSS-Metadata-Standard/install</value>
+    <value type="int" key="PE.EnvironmentAspect.Base">-1</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">3</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.TestAPI</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.2">
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguation.Title">TestConverter</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.Arguments"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory.default">/home/misha/dev/GNSS-Metadata-Standard/install</value>
+    <value type="int" key="PE.EnvironmentAspect.Base">-1</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">4</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.TestConverter</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">3</value>
   </valuemap>
  </data>
  <data>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 
 
-The master branch has been frozen for the duration of the RFC ending Dec 30th 2017
+The master branch has been frozen for the duration of the RFC ending Dec 30th 2017.
+
 If you wish to contribute code, please use the devel branch
 
 

--- a/source/api/inc/GnssMetadata/AttributedObject.h
+++ b/source/api/inc/GnssMetadata/AttributedObject.h
@@ -221,7 +221,7 @@ namespace GnssMetadata
       }
 
       return nFound;
-    };
+    }
 	
 }
 

--- a/source/api/lib/GnssMetadata/Xml/ClusterTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/ClusterTranslator.cpp
@@ -41,7 +41,7 @@ NODELIST_END
 ClusterTranslator::ClusterTranslator() 
 : Translator( (NodeEntry*) _ClusterNodes)
 {
-};
+}
 
 /**
  * Reads a node from the document and parses into metadata.

--- a/source/api/lib/GnssMetadata/Xml/Translator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/Translator.cpp
@@ -274,4 +274,4 @@ void Translator::WriteElement( const char* pszElemName, double dvalue,
 }
 
 
-};
+}

--- a/source/converter/inc/ChunkInterpreter.hpp
+++ b/source/converter/inc/ChunkInterpreter.hpp
@@ -29,7 +29,7 @@ mRightWordShift(rightWordShift)
    // make sure that there is sufficient space for the chunk data
    // no checks made later!
    mDataChunk.resize(countWords);
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 ChunkInterpreter<chunk_t, sample_base_t>::~ChunkInterpreter()
@@ -39,7 +39,7 @@ ChunkInterpreter<chunk_t, sample_base_t>::~ChunkInterpreter()
    for( std::deque<SampleInterpreter*>::iterator it = mSampleInterpreters.begin(); it != mSampleInterpreters.end(); ++it )
       delete (*it);
 
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 void ChunkInterpreter<chunk_t, sample_base_t>::AddSampleInterpreter( SampleInterpreter* splIntrp, const bool front )
@@ -69,7 +69,7 @@ void ChunkInterpreter<chunk_t, sample_base_t>::AddSampleInterpreter( SampleInter
 
    mCallOrderedSampleInterpreters.sort( SampleInterpreter::callOrderSortAscend );
 
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 void* ChunkInterpreter<chunk_t, sample_base_t>::GetChunk()
@@ -77,14 +77,14 @@ void* ChunkInterpreter<chunk_t, sample_base_t>::GetChunk()
    // we should be sure that enough space is allocated, but as we define
    // the ChunkSize at construction time, shouldn't change...
    return &( mDataChunk[0] );
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 uint32_t ChunkInterpreter<chunk_t, sample_base_t>::BytesPerChunk() const
 {
    //so that we can read/memcopy into it
    return ( sizeof( chunk_t ) * static_cast<uint32_t>( mDataChunk.size() ) );
-};
+}
 
 
 template<typename chunk_t,typename sample_base_t>
@@ -108,7 +108,7 @@ void ChunkInterpreter<chunk_t, sample_base_t>::SetSourceEndianness( const GnssMe
     //printf("I am %s endian.\n",(myEndianness==GnssMetadata::Chunk::Little?"Little":"Big"));
 
     mSourceEndiannessIsDifferent = ( myEndianness != srcEndianness );
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 void ChunkInterpreter<chunk_t, sample_base_t>::ChangeCunkEndianness( )
@@ -123,7 +123,7 @@ void ChunkInterpreter<chunk_t, sample_base_t>::ChangeCunkEndianness( )
       (*it) = EndianFunctions::ChangeEndianness( *it );
    }
 
-};
+}
 
 
 template<typename chunk_t,typename sample_base_t>
@@ -145,4 +145,4 @@ void ChunkInterpreter<chunk_t, sample_base_t>::Interpret( )
       (*it)->Interpret( &mDataChunk[0] );
    }
 
-};
+}

--- a/source/converter/inc/EncoderFunctions.h
+++ b/source/converter/inc/EncoderFunctions.h
@@ -50,7 +50,7 @@ namespace SampleEncoderFunctions
    sample_base_t Sign( const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization )
    {
       return ( (pChunk[chunkIndex] >> shift ) & 0x1 ? -1 : 1 );
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> 
    sample_base_t TwosCompliment( const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization )
@@ -70,7 +70,7 @@ namespace SampleEncoderFunctions
 
       //either return the bits or add the sign extension
       return static_cast<sample_base_t>(  ( sign ?  bits | signExtension : bits ) );
-   };
+   }
 
 
    template<typename chunk_t, typename sample_base_t>
@@ -91,7 +91,7 @@ namespace SampleEncoderFunctions
 
 	   //either return the bits or add the sign extension, offset by +1
 	   return static_cast<sample_base_t>((sign ? bits | signExtension : bits) + 1 );
-   };
+   }
    
 
    template<typename chunk_t, typename sample_base_t>
@@ -111,7 +111,7 @@ namespace SampleEncoderFunctions
 	   sample_base_t ans = (sign ? -mag : mag);
 	   return ans;
 
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t>
    sample_base_t SignMagnitudeAdjusted(const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization)
@@ -131,7 +131,7 @@ namespace SampleEncoderFunctions
 	   //either return the bits or add the sign extension
 	   sample_base_t ans = (sign ? -mag : mag);
 	   return ans;
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t>
    sample_base_t OffsetBinary(const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization)
@@ -145,7 +145,7 @@ namespace SampleEncoderFunctions
 	   chunk_t offset = 0x1 << (quantization - 1);
 
 	   return static_cast<sample_base_t>(bits) - static_cast<sample_base_t>(offset);
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t>
    sample_base_t OffsetBinaryAdjusted(const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization)
@@ -159,7 +159,7 @@ namespace SampleEncoderFunctions
 	   chunk_t offset = (0x1 << quantization) - 1;
 
 	   return static_cast<sample_base_t>(bits) - static_cast<sample_base_t>(offset);
-   };
+   }
 
 
    template<typename chunk_t, typename sample_base_t>
@@ -180,7 +180,7 @@ namespace SampleEncoderFunctions
 	   chunk_t offset = 0x1 << (quantization - 1);
 
 	   return static_cast<sample_base_t>(gray) - static_cast<sample_base_t>(offset);
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t>
    sample_base_t OffsetGrayAdjusted(const chunk_t* pChunk, uint32_t chunkIndex, uint32_t shift, uint32_t quantization)
@@ -200,7 +200,7 @@ namespace SampleEncoderFunctions
 	   chunk_t offset = (0x1 << quantization) - 1;
 
 	   return static_cast<sample_base_t>(gray << 1) - static_cast<sample_base_t>(offset);
-   };
+   }
 
 
    template<typename chunk_t, typename sample_base_t>
@@ -210,10 +210,10 @@ namespace SampleEncoderFunctions
 	   int8_t sample =  static_cast<int8_t>( (pChunk[chunkIndex] >> shift) & 0xff );
 
 	   return static_cast<sample_base_t>(sample);
-   };
+   }
 
 
-};// end namespace SampleEncoderFunctions
+}// end namespace SampleEncoderFunctions
 
 
 #endif //NAMESPACE_EncoderFunctions

--- a/source/converter/inc/EndianFunctions.h
+++ b/source/converter/inc/EndianFunctions.h
@@ -36,7 +36,7 @@ namespace EndianFunctions
    T ChangeEndianness( const T in )
    {
       return in;
-   };
+   }
 
 	uint16_t ChangeEndianness( const uint16_t in );
 
@@ -45,6 +45,6 @@ namespace EndianFunctions
 	uint64_t ChangeEndianness( const uint64_t in );
 
 	
-};//end namespace EndianFunctions
+}//end namespace EndianFunctions
 
 #endif //NAMESPACE_EndianFunctions

--- a/source/converter/inc/FormatFunctions.h
+++ b/source/converter/inc/FormatFunctions.h
@@ -69,7 +69,7 @@ namespace SampleFormatFunctions
 
       sampleSink->AddSample( IF );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void IFn( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -80,7 +80,7 @@ namespace SampleFormatFunctions
 
       sampleSink->AddSample( IF );
 	
-   };
+   }
 
 
    template<typename chunk_t, typename sample_base_t> void IQ( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
@@ -95,7 +95,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void IQn( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -109,7 +109,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void InQ( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -123,7 +123,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void InQn( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -137,7 +137,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void QI( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -151,7 +151,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void QIn( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -165,7 +165,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void QnI( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -179,7 +179,7 @@ namespace SampleFormatFunctions
       sampleSink->AddSample( I, Q );
       //sampleSink->AddSample( Q );
 	
-   };
+   }
 
    template<typename chunk_t, typename sample_base_t> void QnIn( sample_base_t (*encoderFunc)( const chunk_t* , uint32_t, uint32_t, uint32_t ), const chunk_t* pChunk, uint32_t chunkIndex, uint32_t residualBitIndex, uint32_t bitWidth, SampleSink* sampleSink )
    {
@@ -192,7 +192,7 @@ namespace SampleFormatFunctions
       
       sampleSink->AddSample( I, Q );
       
-   };
+   }
    
 
    // Specialized FormatFunctions (including native type encoder functions
@@ -207,8 +207,8 @@ namespace SampleFormatFunctions
       
       sampleSink->AddSample( I, Q );
 
-   };
+   }
 
-};//end namespace SampleFormatFunctions
+}//end namespace SampleFormatFunctions
 
 #endif //NAMESPACE_FormatFunctions

--- a/source/converter/inc/SampleBuffer.hpp
+++ b/source/converter/inc/SampleBuffer.hpp
@@ -38,7 +38,7 @@ SampleBuffer<sample_base_t>::~SampleBuffer(void)
    //close the stream, if it is not done so already.
    Close();
 
-};
+}
 
 template<typename sample_base_t>
 bool SampleBuffer<sample_base_t>::Open( )
@@ -53,7 +53,7 @@ bool SampleBuffer<sample_base_t>::Open( )
    mBufferPos  = -1;
    
    return this->mIsOpen;
-};
+}
 
 
 template<typename sample_base_t>
@@ -64,7 +64,7 @@ void SampleBuffer<sample_base_t>::Close()
 
    Flush();
 
-};
+}
 
 template<typename sample_base_t>
 void SampleBuffer<sample_base_t>::Flush()
@@ -75,7 +75,7 @@ void SampleBuffer<sample_base_t>::Flush()
 
    mBufferPos = -1;
 
-};
+}
 
 template<typename sample_base_t>
 void SampleBuffer<sample_base_t>::DoAddSample( sample_base_t x )
@@ -97,7 +97,7 @@ void SampleBuffer<sample_base_t>::DoAddSample( sample_base_t x )
    
    mSampleBuffer[mBufferPos] = x;
    
-};
+}
 
 template<typename sample_base_t>
 void SampleBuffer<sample_base_t>::DoAddSample( sample_base_t x, sample_base_t y )
@@ -119,7 +119,7 @@ void SampleBuffer<sample_base_t>::DoAddSample( sample_base_t x, sample_base_t y 
    mSampleBuffer[mBufferPos-1] = x;
    mSampleBuffer[mBufferPos]   = y;
    
-};
+}
 
 
 template<typename sample_base_t>
@@ -130,7 +130,7 @@ uint32_t SampleBuffer<sample_base_t>:: DoGetSamples( const void** pbuff ) const
 
    //indicate how many samples are there
    return static_cast<uint32_t>(mBufferPos+1);
-};
+}
 
 
 

--- a/source/converter/inc/SampleConverter.hpp
+++ b/source/converter/inc/SampleConverter.hpp
@@ -108,7 +108,7 @@ bool SampleConverter::Open( GnssMetadata::Metadata& md, std::string path_prefix 
 
    return mIsOpen;
 
-};
+}
 
 
 
@@ -158,7 +158,7 @@ bool SampleConverter::CreateBlockInterpreter( GnssMetadata::Metadata& md, Sample
    //
    return true;
 
-};
+}
 
 
 
@@ -289,5 +289,5 @@ bool SampleConverter::CreateChunkInterpreter( GnssMetadata::Metadata& md, Sample
    //
    return true;
 
-};
+}
 

--- a/source/converter/inc/SampleFileSink.hpp
+++ b/source/converter/inc/SampleFileSink.hpp
@@ -41,7 +41,7 @@ SampleFileSink<sample_base_t>::~SampleFileSink(void)
    //close the stream, if it is not done so already.
    Close();
 
-};
+}
 
 template<typename sample_base_t>
 bool SampleFileSink<sample_base_t>::Open( )
@@ -109,7 +109,7 @@ void SampleFileSink<sample_base_t>::DoAddSample( sample_base_t x )
    if( mIndexOfNextSample == mBufferSize)
       Flush();
    
-};
+}
 
 template<typename sample_base_t>
 void SampleFileSink<sample_base_t>::DoAddSample( sample_base_t x, sample_base_t y )
@@ -127,7 +127,7 @@ void SampleFileSink<sample_base_t>::DoAddSample( sample_base_t x, sample_base_t 
    if( mIndexOfNextSample == mBufferSize)
       Flush();
    
-};
+}
 
 template<typename sample_base_t>
 void SampleFileSink<sample_base_t>::Flush()

--- a/source/converter/inc/SampleFrontEnd.hpp
+++ b/source/converter/inc/SampleFrontEnd.hpp
@@ -35,7 +35,7 @@ const SampleSource* SampleFrontEnd<sample_base_t>::GetSource( const std::string 
    
    return sampleSource;
  
-};
+}
 
 template<typename sample_base_t>
 const SampleStreamInfo* SampleFrontEnd<sample_base_t>::GetSourceInfo( const std::string sinkName ) const
@@ -51,7 +51,7 @@ const SampleStreamInfo* SampleFrontEnd<sample_base_t>::GetSourceInfo( const std:
    
    return mit->second.second;
  
-};
+}
 
 
 template<typename sample_base_t>
@@ -69,7 +69,7 @@ std::map< std::string, std::pair<const SampleSource*, const SampleStreamInfo*> >
    
    return sourceMap;
    
-};
+}
 
 
 template<typename sample_base_t>
@@ -86,6 +86,6 @@ void SampleFrontEnd<sample_base_t>::Clear(  )
          pSampleBuff->Flush();
    }
  
-};
+}
 
 

--- a/source/converter/inc/SampleInterpreterFactory.hpp
+++ b/source/converter/inc/SampleInterpreterFactory.hpp
@@ -57,14 +57,14 @@ SampleInterpreterFactory<chunk_t,sample_base_t>::SampleInterpreterFactory()
    //specialized FormatFunctions (native types)
    mFormatFunctionMap[ GnssMetadata::IonStream::Int8IQ ] = &SampleFormatFunctions::Int8IQ<chunk_t,sample_base_t>;
 
-};
+}
 
 template<typename chunk_t, typename sample_base_t>
 SampleInterpreterFactory<chunk_t,sample_base_t>::~SampleInterpreterFactory()
 {
 
 
-};
+}
 
 template<typename chunk_t, typename sample_base_t>
 bool SampleInterpreterFactory<chunk_t,sample_base_t>::Create(
@@ -130,7 +130,7 @@ bool SampleInterpreterFactory<chunk_t,sample_base_t>::Create(
 
    return true;
 
-};
+}
 
 template<typename chunk_t, typename sample_base_t>
 uint32_t SampleInterpreterFactory<chunk_t,sample_base_t>::BitWidth( const GnssMetadata::IonStream::SampleFormat& fmt, const size_t& qnt )
@@ -146,5 +146,5 @@ uint32_t SampleInterpreterFactory<chunk_t,sample_base_t>::BitWidth( const GnssMe
          return 2 * static_cast<uint32_t>(qnt);
    }
 
-};
+}
 

--- a/source/converter/inc/SampleSinkFactory.hpp
+++ b/source/converter/inc/SampleSinkFactory.hpp
@@ -25,7 +25,7 @@ SampleSinkFactory<sample_sink_t>::SampleSinkFactory()
    
    mSampleSinks.clear();
    
-};
+}
 
 template<typename sample_sink_t>
 SampleSinkFactory<sample_sink_t>::~SampleSinkFactory()
@@ -58,7 +58,7 @@ SampleSink* SampleSinkFactory<sample_sink_t>::GetSampleSink( const std::string s
    
    return mSampleSinks[sinkName].first;
    
-};
+}
 
 template<typename sample_sink_t>
 SampleStreamInfo* SampleSinkFactory<sample_sink_t>::GetSampleStreamInfo(const std::string sinkName)
@@ -68,5 +68,5 @@ SampleStreamInfo* SampleSinkFactory<sample_sink_t>::GetSampleStreamInfo(const st
    
    return mSampleSinks[sinkName].second;
    
-};
+}
 

--- a/source/converter/inc/SampleStatisticsSink.hpp
+++ b/source/converter/inc/SampleStatisticsSink.hpp
@@ -38,7 +38,7 @@ SampleStatisticsSink<sample_base_t>::~SampleStatisticsSink(void)
    //close the stream, if it is not done so already.
    Close();
 
-};
+}
 
 template<typename sample_base_t>
 bool SampleStatisticsSink<sample_base_t>::Open( )
@@ -104,7 +104,7 @@ void SampleStatisticsSink<sample_base_t>::Report()
    printf("\n");
    
 
-};
+}
 
 
 

--- a/source/converter/inc/SinkedSampleInterpreter.hpp
+++ b/source/converter/inc/SinkedSampleInterpreter.hpp
@@ -40,7 +40,7 @@ template<typename chunk_t,typename sample_base_t>
 SinkedSampleInterpreter<chunk_t,sample_base_t>::~SinkedSampleInterpreter( )
 { 
 
-};
+}
 
 template<typename chunk_t,typename sample_base_t>
 void SinkedSampleInterpreter<chunk_t,sample_base_t>::SetChunkOffset( const uint32_t chunkOffsetInBits )
@@ -56,6 +56,6 @@ void SinkedSampleInterpreter<chunk_t,sample_base_t>::Interpret( const void* vChu
    const chunk_t* pChunk = reinterpret_cast<const chunk_t*>( vChunk );
    (*mFormatFunc)( mEncodingFunc, pChunk, mChunkIndex, mResidualBitIndex, mBitWidth, mSampleSink );
 
-};
+}
 
 

--- a/source/converter/inc/statistics.h
+++ b/source/converter/inc/statistics.h
@@ -23,6 +23,9 @@ public:
    Statistics(double rangeMin, double rangeMax, int64_t samplesToSkip = 0 );
    virtual ~Statistics(void);
 
+   static double constexpr MaxPossibleValue = 1.0e308;
+   static double constexpr MinPossibleValue = -1.0e308;
+
    double Mean()       const;
    double Min()        const;
    double Max()        const;

--- a/source/converter/lib/BlockInterpreter.cpp
+++ b/source/converter/lib/BlockInterpreter.cpp
@@ -29,7 +29,7 @@ mFooterBytes(footerBytes)
 
 	mChunkInterpreters.resize(0);
 
-};
+}
 
 BlockInterpreter::~BlockInterpreter()
 {
@@ -37,14 +37,14 @@ BlockInterpreter::~BlockInterpreter()
    for( std::vector<Chunk*>::iterator It = mChunkInterpreters.begin(); It != mChunkInterpreters.end(); ++It )
       delete (*It);
 
-};
+}
 
 void BlockInterpreter::AddChunk(Chunk* newChunk)
 {
 
 	mChunkInterpreters.push_back(newChunk);
 
-};
+}
 
 
 bool BlockInterpreter::Interpret( BinaryFileSource& packedFile, uint32_t& bytesProcessed, uint32_t bytesToProcess )
@@ -101,7 +101,7 @@ bool BlockInterpreter::Interpret( BinaryFileSource& packedFile, uint32_t& bytesP
    
    //otherwise, a full block was read
    return true;
-};
+}
 
 
 
@@ -145,7 +145,7 @@ bool BlockInterpreter::InterpretChunk( BinaryFileSource& packedFile )
    
    //a full chunk set was read
    return true;
-};
+}
 
 
 

--- a/source/converter/lib/EndianFunctions.cpp
+++ b/source/converter/lib/EndianFunctions.cpp
@@ -35,13 +35,13 @@ namespace EndianFunctions
    uint8_t ChangeEndianness( const uint8_t in )
 	{
 		return in;
-	};
+    }
 
 	uint16_t ChangeEndianness( const uint16_t in )
 	{
 		return  ( in >> 8 ) |   //move byte 1 to 0
 				  ( in << 8 );    //move byte 0 to 1
-	};
+    }
 
 	uint32_t ChangeEndianness( const uint32_t in )
 	{
@@ -49,7 +49,7 @@ namespace EndianFunctions
 				  (( in >>  8 ) & 0x0000ff00 ) |	// move byte 1 to byte 2
 				  (( in <<  8 ) & 0x00ff0000 ) |	// move byte 2 to byte 1
 				  (( in << 24 ) & 0xff000000 );	// move byte 0 to byte 3;
-	};
+    }
 
 	uint64_t ChangeEndianness( const uint64_t in )
 	{
@@ -62,6 +62,6 @@ namespace EndianFunctions
 				  (( in << 24 ) &  0x0000ff0000000000) |  // move byte 2 to byte 5
 				  (( in << 40 ) &  0x00ff000000000000) |  // move byte 1 to byte 6
 				  (( in << 56 ) &  0xff00000000000000);   // move byte 0 to byte 7
-	};	
+    }
 	
-};//end namespace EndianFunctions
+}//end namespace EndianFunctions

--- a/source/converter/lib/LaneInterpreter.cpp
+++ b/source/converter/lib/LaneInterpreter.cpp
@@ -29,7 +29,7 @@ mFileURL(fileURL)
 	
 	mBlockInterpreters.resize(0);
 			
-};
+}
 
 LaneInterpreter::~LaneInterpreter()
 {
@@ -37,24 +37,24 @@ LaneInterpreter::~LaneInterpreter()
 	for( std::vector<BlockInterpreter*>::iterator It = mBlockInterpreters.begin(); It != mBlockInterpreters.end(); ++It)
 		delete (*It);
 	
-};
+}
 
 void LaneInterpreter::AddBlock( BlockInterpreter* newBlock )
 {
    
    mBlockInterpreters.push_back( newBlock );
    
-};
+}
 
 std::vector<BlockInterpreter*>& LaneInterpreter::Blocks()
 {
    
    return mBlockInterpreters;
    
-};
+}
 
 const std::string LaneInterpreter::FileURL() const
 {
    return mFileURL;
-};
+}
 

--- a/source/converter/lib/SampleConverter.cpp
+++ b/source/converter/lib/SampleConverter.cpp
@@ -32,7 +32,7 @@ mSampleSinkFactory(ssFactory)
 
    
       
-};
+}
 
 SampleConverter::~SampleConverter()
 {
@@ -40,7 +40,7 @@ SampleConverter::~SampleConverter()
    //just check that it has been closed
    Close();
 
-};
+}
 
 void SampleConverter::Close()
 {
@@ -59,7 +59,7 @@ void SampleConverter::Close()
       
    }
    mIsOpen = false;
-};
+}
 
 
 void SampleConverter::Convert( const uint32_t bytesToProcess )
@@ -107,7 +107,7 @@ void SampleConverter::Convert( const uint32_t bytesToProcess )
       while( readBlockOK );
 
    }//end for( lnIt )
-};
+}
 
 
 
@@ -160,7 +160,7 @@ bool SampleConverter::Load( const uint32_t chunksToProcess )
    }//end for( lnIt )
 
    return readAllOK;
-};
+}
 
 
 

--- a/source/converter/lib/statistics.cpp
+++ b/source/converter/lib/statistics.cpp
@@ -20,8 +20,8 @@ mRangeMax(0)
 Statistics::Statistics(double rangeMin, double rangeMax, int64_t samplesToSkip ):
 mMean(0.0),
 mPower(0.0),
-mMin( 1.0e308 ),
-mMax( -1.0e308 ),
+mMin( MaxPossibleValue ),
+mMax( MinPossibleValue ),
 mNumSamples(0),
 mNumCalls(0),
 mSamplesToSkip(samplesToSkip),
@@ -41,8 +41,8 @@ Statistics::~Statistics(void)
 void Statistics::Reset()
 {
    mMean          = 0.0;
-   mMin           = 1.0e308;
-   mMax           = -1.0e308;
+   mMin           = MaxPossibleValue;
+   mMax           = MinPossibleValue;
    mPower         = 0.0;
    mNumSamples    = 0;
    mNumCalls      = 0;

--- a/source/converter/lib/statistics.cpp
+++ b/source/converter/lib/statistics.cpp
@@ -15,7 +15,7 @@ mRangeMin(0),
 mRangeMax(0)
 {
 
-};
+}
 
 Statistics::Statistics(double rangeMin, double rangeMax, int64_t samplesToSkip ):
 mMean(0.0),
@@ -30,13 +30,13 @@ mRangeMin(rangeMin),
 mRangeMax(rangeMax)
 {
 
-};
+}
 
 
 Statistics::~Statistics(void)
 {
 
-};
+}
 
 void Statistics::Reset()
 {
@@ -46,7 +46,7 @@ void Statistics::Reset()
    mPower         = 0.0;
    mNumSamples    = 0;
    mNumCalls      = 0;
-};
+}
 
 void Statistics::SetSamplesToSkip( int64_t samplesToSkip )
 {
@@ -70,38 +70,38 @@ void Statistics::AddSample( double x )
     mMin = ( x < mMin ? x : mMin );
     mMax = ( x > mMax ? x : mMax );
 
-};
+}
 
 double Statistics::NumSamples() const
 {
    return static_cast<double>( mNumSamples );
-};
+}
 
 double Statistics::Mean() const
 {
   return mMean;
-};
+}
 double Statistics::Min() const
 {
   return mMin;
-};
+}
 double Statistics::Max() const
 {
   return mMax;
-};
+}
 double Statistics::Power() const
 {
   return mPower;
-};
+}
 double Statistics::RMS() const
 {
     return std::sqrt( Power() );
-};
+}
 double Statistics::Variance() const
 {
   return Power() - std::pow( Mean(), 2 );
-};
+}
 double Statistics::StdDev() const
 {
   return std::sqrt( Variance() );
-};
+}


### PR DESCRIPTION
- CMakeList.txt: Added -pedantic compiler option; 
- Removed unnecessary semicolons after closing curly brackets; 
- Blacklisted CMakeList.txt.user in .gitignore;
- Statistics: replaced magic numbers for max and min possible values with static constexpr;