### PR TITLE
Fix: trim xml strings before parsing them

### DIFF
--- a/source/api/inc/GnssMetadata/Xml/Translator.h
+++ b/source/api/inc/GnssMetadata/Xml/Translator.h
@@ -129,6 +129,13 @@ namespace GnssMetadata
 
 	private:
 		NodeEntry* _nodesAllowed;
+
+	public:
+		/**
+		 * Helper function that trims a C string and outputs its length
+		 */
+		static const char* TrimString(const char* str, size_t* len);
+
 	};
 }
 #endif

--- a/source/api/lib/GnssMetadata/Xml/ChunkTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/ChunkTranslator.cpp
@@ -45,9 +45,11 @@ NODELIST_END
 static const char* _szEndian[] = {"Big","Little", "Undefined"};
 Chunk::WordEndian ToEndian( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 3; i++)
 	{
-		if( strcmp( _szEndian[i], pszFmt) == 0)
+		if( strncmp( _szEndian[i], trimmedPszFmt, len) == 0)
 			return (Chunk::WordEndian)i;
 	}
 	return (Chunk::WordEndian)2;
@@ -57,9 +59,11 @@ Chunk::WordEndian ToEndian( const char* pszFmt)
 static const char* _szWordPadding[] = {"None","Head","Tail"};
 Chunk::WordPadding ToWordPadding( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 3; i++)
 	{
-		if( strcmp( _szWordPadding[i], pszFmt) == 0)
+		if( strncmp( _szWordPadding[i], trimmedPszFmt, len) == 0)
 			return (Chunk::WordPadding)i;
 	}
 	return (Chunk::WordPadding)2;
@@ -69,9 +73,11 @@ Chunk::WordPadding ToWordPadding( const char* pszFmt)
 static const char* _szWordShift[] = {"Left","Right"};
 Chunk::WordShift ToWordShift( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 2; i++)
 	{
-		if( strcmp( _szWordShift[i], pszFmt) == 0)
+		if( strncmp( _szWordShift[i], trimmedPszFmt, len) == 0)
 			return (Chunk::WordShift)i;
 	}
 	return (Chunk::WordShift)2;

--- a/source/api/lib/GnssMetadata/Xml/DurationTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/DurationTranslator.cpp
@@ -38,9 +38,11 @@ using namespace tinyxml2;
 static const char* _szfmts[] = {"sec","msec", "usec", "nsec", "psec"};
 static Duration::DurationFormat ToFormat( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 5; i++)
 	{
-		if( strcmp( _szfmts[i], pszFmt) == 0)
+		if( strncmp( _szfmts[i], trimmedPszFmt, len) == 0)
 			return (Duration::DurationFormat)i;
 	}
 	return (Duration::DurationFormat)0;

--- a/source/api/lib/GnssMetadata/Xml/FrequencyTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/FrequencyTranslator.cpp
@@ -37,9 +37,11 @@ using namespace tinyxml2;
 static const char* _szfmts[] = {"Hz","kHz","MHz", "GHz", "Ratio"};
 static Frequency::FrequencyFormat ToFormat( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 4; i++)
 	{
-		if( strcmp( _szfmts[i], pszFmt) == 0)
+		if( strncmp( _szfmts[i], trimmedPszFmt, len) == 0)
 			return (Frequency::FrequencyFormat)i;
 	}
 	return (Frequency::FrequencyFormat)0;

--- a/source/api/lib/GnssMetadata/Xml/LumpTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/LumpTranslator.cpp
@@ -42,9 +42,11 @@ LumpTranslator::LumpTranslator()
 static const char* _szShiftFmts[] = { "Left","Right", "Undefined" };
 static Lump::LumpShift ToLumpShiftFormat(const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
 	for (unsigned int i = 0; i < 3; i++)
 	{
-		if (strcmp(_szShiftFmts[i], pszFmt) == 0)
+		if (strncmp(_szShiftFmts[i], trimmedPszFmt, len) == 0)
 			return (Lump::LumpShift)i;
 	}
 	return (Lump::LumpShift)2;

--- a/source/api/lib/GnssMetadata/Xml/SourceTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/SourceTranslator.cpp
@@ -43,9 +43,11 @@ NODELIST_END
 static const char* _szSourceType[] = {"UndefinedType","Patch", "Dipole", "Helical", "Quadrilfilar", "Simulator", "Other"};
 Source::SourceType ToSourceType( const char* psz)
 {
+	size_t len;
+	const char* trimmedPsz = Translator::TrimString(psz, &len);
     for( unsigned int i = 0; i < 7; i++)
 	{
-		if( strcmp( _szSourceType[i], psz) == 0)
+		if( strncmp( _szSourceType[i], trimmedPsz, len) == 0)
 			return (Source::SourceType)i;
 	}
 	return (Source::SourceType)0;
@@ -55,9 +57,11 @@ Source::SourceType ToSourceType( const char* psz)
 static const char* _szSourcePolarization[] = {"UndefinedPolarization", "RHCP", "LHCP", "Linear", "Horizontal", "Vertical"};
 Source::SourcePolarization ToSourcePolarization( const char* psz)
 {
+	size_t len;
+	const char* trimmedPsz = Translator::TrimString(psz, &len);
     for( unsigned int i = 0; i < 6; i++)
 	{
-		if( strcmp( _szSourcePolarization[i], psz) == 0)
+		if( strncmp( _szSourcePolarization[i], trimmedPsz, len) == 0)
 			return (Source::SourcePolarization)i;
 	}
 	return (Source::SourcePolarization)2;

--- a/source/api/lib/GnssMetadata/Xml/StreamTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/StreamTranslator.cpp
@@ -37,9 +37,11 @@ using namespace tinyxml2;
 static const char* _szAlignFmts[] = {"Left","Right", "Undefined"};
 static IonStream::StreamAlignment ToAlignmentFormat( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned  int i = 0; i < 3; i++)
 	{
-		if( strcmp( _szAlignFmts[i], pszFmt) == 0)
+		if( strncmp( _szAlignFmts[i], trimmedPszFmt, len) == 0)
 			return (IonStream::StreamAlignment)i;
 	}
 	return (IonStream::StreamAlignment)2;
@@ -48,9 +50,11 @@ static IonStream::StreamAlignment ToAlignmentFormat( const char* pszFmt)
 static const char* _szShiftFmts[] = {"Left","Right", "Undefined"};
 static IonStream::StreamShift ToStreamShiftFormat( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned  int i = 0; i < 3; i++)
 	{
-		if( strcmp(_szShiftFmts[i], pszFmt) == 0)
+		if( strncmp(_szShiftFmts[i], trimmedPszFmt, len) == 0)
 			return (IonStream::StreamShift)i;
 	}
 	return (IonStream::StreamShift)2;
@@ -61,9 +65,11 @@ static const char* _szSampleFmts[] = {"IF","IFn","IQ","IQn","InQ","InQn","QI","Q
 
 static IonStream::SampleFormat ToSampleFormat( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 10; i++)
 	{
-		if( strcmp( _szSampleFmts[i], pszFmt) == 0)
+		if( strncmp( _szSampleFmts[i], trimmedPszFmt, len) == 0)
 			return (IonStream::SampleFormat)i;
 	}
 	return (IonStream::SampleFormat)2;

--- a/source/api/lib/GnssMetadata/Xml/SystemTranslator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/SystemTranslator.cpp
@@ -46,9 +46,11 @@ NODELIST_END
 static const char* _szTypes[] = {"Undefined", "Processor", "Receiver", "Simulator"};
 System::SystemType ToSystemType( const char* pszFmt)
 {
+	size_t len;
+	const char* trimmedPszFmt = Translator::TrimString(pszFmt, &len);
     for( unsigned int i = 0; i < 4; i++)
 	{
-		if( strcmp( _szTypes[i], pszFmt) == 0)
+		if( strncmp( _szTypes[i], trimmedPszFmt, len) == 0)
 			return (System::SystemType)i;
 	}
 	return (System::SystemType)3;

--- a/source/api/lib/GnssMetadata/Xml/Translator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/Translator.cpp
@@ -284,5 +284,16 @@ void Translator::WriteElement( const char* pszElemName, double dvalue,
 	}
 }
 
+const char* Translator::TrimString(const char* str, size_t* len) {
+	while (str[0] == ' ') {
+		str++;
+	}
+	(*len) = strlen(str);
+	while (str[(*len) - 1] == ' ') {
+		(*len)--;
+	}
+	return str;
+}
+
 
 }

--- a/source/api/lib/GnssMetadata/Xml/Translator.cpp
+++ b/source/api/lib/GnssMetadata/Xml/Translator.cpp
@@ -167,7 +167,9 @@ bool Translator::ReadFirstElement( const char* pszelem,
 	}
 	else
 	{
-		return (strcmp( pchild->GetText(),"false")==0);
+		size_t len;
+		const char* trimmedText = TrimString(pchild->GetText(), &len);
+		return (strcmp( trimmedText,"false")==0);
 	}
 }
 const char* Translator::ReadFirstElement( const char* pszelem,
@@ -210,7 +212,9 @@ size_t Translator::ReadFirstElement( const char* pszelem,
 	}
 	else
 	{
-		return atol( pchild->GetText());
+		size_t len;
+		const char* trimmedText = TrimString(pchild->GetText(), &len);
+		return atol(trimmedText);
 	}
 }
 
@@ -232,7 +236,9 @@ double Translator::ReadFirstElement( const char* pszelem,
 	}
 	else
 	{
-		return atof( pchild->GetText());
+		size_t len;
+		const char* trimmedText = TrimString(pchild->GetText(), &len);
+		return atof(trimmedText);
 	}
 
 }


### PR DESCRIPTION
Some systems and libraries add leading and/or trailing whitespaces when writing text into XML elements. For instance, the specific system I am working with now outputs XML in this format:

```xml
<stream id="L1">
  <ratefactor> 1 </ratefactor>
  <quantization> 8 </quantization>
  <packedbits> 16 </packedbits>
  <alignment> Right </alignment>
  <shift> Left </shift>
  <format> IQ </format>
  <encoding> TC </encoding>
  <band id="L1"/>
</stream>
```

This is problematic since the API will try to parse every element with the spaces included. So for the `ratefactor`, it will call `atol(" 1 ")`, which will not parse properly. Another case is string comparison, `alignment` calls `strcmp("Right", " Right ")`, which returns false.

I propose introducing a `TrimString` static function to the `Translator` class. This function accepts a `const char*` string and a pointer to a `size_t`. It will return a new pointer to the beginning of the string after any whitespaces and set the `size_t*` to the actual length. This effectively trims the string in place.

We can then use this new pointer to call `atol()` and `atof()`, which will parse numbers properly despite any trailing spaces. For the case of comparing string, we can call `strncmp()` instead, which will accept our length value and compare just those characters ignoring trailing spaces.

I have tested these changes in my setup and it now parses the metadata file without an issue.